### PR TITLE
FIX: Ensure geoblocking is inserted after failover middleware

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -10,7 +10,12 @@ enabled_site_setting :geoblocking_enabled
 require_relative("lib/geoblocking_middleware")
 
 DiscourseEvent.on(:after_initializers) do
-  if Rails.configuration.multisite
+  # Failover and multisite middlewares are added to the stack based on the site's configuration.
+  # If either of them exist, we must run the geoblocking middleware after them to avoid
+  # unexpected behaviours
+  if defined?(RailsFailover::ActiveRecord) && Rails.configuration.active_record_rails_failover
+    Rails.configuration.middleware.insert_after(RailsFailover::ActiveRecord::Middleware, GeoblockingMiddleware)
+  elsif Rails.configuration.multisite
     Rails.configuration.middleware.insert_after(RailsMultisite::Middleware, GeoblockingMiddleware)
   else
     Rails.configuration.middleware.unshift(GeoblockingMiddleware)


### PR DESCRIPTION
This logic will check for Multisite and Failover middlewares, then insert the geoblocking middleware after the latest one.