### PR TITLE
FIX: Move geoblocking later in the middleware stack

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -10,16 +10,8 @@ enabled_site_setting :geoblocking_enabled
 require_relative("lib/geoblocking_middleware")
 
 DiscourseEvent.on(:after_initializers) do
-  # Failover and multisite middlewares are added to the stack based on the site's configuration.
-  # If either of them exist, we must run the geoblocking middleware after them to avoid
-  # unexpected behaviours
-  if defined?(RailsFailover::ActiveRecord) && Rails.configuration.active_record_rails_failover
-    Rails.configuration.middleware.insert_after(RailsFailover::ActiveRecord::Middleware, GeoblockingMiddleware)
-  elsif Rails.configuration.multisite
-    Rails.configuration.middleware.insert_after(RailsMultisite::Middleware, GeoblockingMiddleware)
-  else
-    Rails.configuration.middleware.unshift(GeoblockingMiddleware)
-  end
+  # Must be added after DebugExceptions so that postgres errors trigger failover
+  Rails.configuration.middleware.insert_after(Logster::Middleware::DebugExceptions, GeoblockingMiddleware)
 end
 
 after_initialize do


### PR DESCRIPTION
This ensures that errors from the geoblocking middleware are caught, logged
and handled. In particular, postgres connection errors will now trigger failover.