### PR TITLE
FIX: Handle requests with invalid API keys

### DIFF
--- a/lib/geoblocking_middleware.rb
+++ b/lib/geoblocking_middleware.rb
@@ -18,6 +18,8 @@ class GeoblockingMiddleware
   def not_admin(env)
     user = CurrentUser.lookup_from_env(env)
     user.nil? || !user.admin?
+  rescue Discourse::InvalidAccess
+    true
   end
 
   def check_route(env)

--- a/spec/requests/geoblocking_middleware_spec.rb
+++ b/spec/requests/geoblocking_middleware_spec.rb
@@ -148,4 +148,23 @@ describe GeoblockingMiddleware do
       end
     end
   end
+
+  describe 'using an invalid API key' do
+    it "treats invalid API key requests as non-admin requests" do
+      user = Fabricate(:user)
+      api_key = ApiKey.create!(user: user, revoked_at: Time.zone.now, last_used_at: nil)
+
+      env = make_env(
+        {
+          "HTTP_API_USERNAME" => user.username.downcase,
+          "HTTP_API_KEY" => api_key.key,
+          "REMOTE_ADDR" => us_ip,
+          "REQUEST_URI" => "/",
+        }
+      )
+
+      status, _ = subject.call(env)
+      expect(status).to eq(200)
+    end
+  end
 end


### PR DESCRIPTION
Looking for the current user with an invalid API key raises an exception, which the middleware didn't handle. It should treat requests made with invalid keys as non-admin requests.

https://dev.discourse.org/logs/show/a30cd5d7990ad68309343f11c7826a44