### PR TITLE
FIX: Skip redirect_to_login_if_required if blocked

### DIFF
--- a/app/controllers/geoblocking_controller.rb
+++ b/app/controllers/geoblocking_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class GeoblockingController < ApplicationController
-  skip_before_action :check_xhr, :preload_json
+  skip_before_action :check_xhr, :preload_json, :redirect_to_login_if_required
 
   def blocked
     respond_to do |format|

--- a/spec/requests/geoblocking_spec.rb
+++ b/spec/requests/geoblocking_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe GeoblockingController do
+  it 'does not redirect users in a loop if login_required' do
+    SiteSetting.login_required = true
+    SiteSetting.geoblocking_use_whitelist = true
+    SiteSetting.geoblocking_whitelist = 'EU'
+
+    get Discourse.base_url
+    expect(response.status).to eq(403)
+    expect(response.body).to include('Access forbidden based on location.')
+  end
+end


### PR DESCRIPTION
It does not make sense to redirect user to login if they are blocked.
This was causing issues for sites with login_required enabled because
they had to be logged in to see the error, but they were stuck in a
redirect loop because redirect_to_login_if_required was called over and
over by the initial controller and then by GeoblockingController too.