### PR TITLE
FIX: Check for exact country code match

### DIFF
--- a/spec/requests/geoblocking_middleware_spec.rb
+++ b/spec/requests/geoblocking_middleware_spec.rb
@@ -38,6 +38,15 @@ describe GeoblockingMiddleware do
       expect(status).to eq(200)
     end
 
+    it 'checks for exact match' do
+      SiteSetting.geoblocking_countries = "US-TEST"
+
+      env = make_env("REMOTE_ADDR" => us_ip)
+
+      status, _ = subject.call(env)
+      expect(status).to eq(200)
+    end
+
     it 'does not block non-European IP by default' do
       env = make_env("REMOTE_ADDR" => us_ip)
 


### PR DESCRIPTION
For example, the plugin blocked if the country code was "UA" and the
list contained "UA-14" because it matched the substring "UA".