### PR TITLE
FIX: Block using IP if geoname IDs are blank

### DIFF
--- a/lib/geoblocking_middleware.rb
+++ b/lib/geoblocking_middleware.rb
@@ -48,10 +48,8 @@ class GeoblockingMiddleware
     return default_blocked if !info
 
     country_code = info[:country_code].presence&.upcase
-    return default_blocked if !country_code
-
     geoname_ids = info[:geoname_ids].presence
-    return default_blocked if !geoname_ids
+    return default_blocked if !country_code && !geoname_ids
 
     if default_blocked
       return true if !DiscourseGeoblocking.allowed_countries.include?(country_code) && !geoname_ids.any? { |id| DiscourseGeoblocking.allowed_geoname_ids.include?(id) }

--- a/spec/requests/geoblocking_middleware_spec.rb
+++ b/spec/requests/geoblocking_middleware_spec.rb
@@ -65,6 +65,18 @@ describe GeoblockingMiddleware do
       expect(status).to eq(403)
     end
 
+    it 'blocks ip even if geoname ids are missing' do
+      info = DiscourseIpInfo.get(gb_ip)
+      info[:geoname_ids] = []
+      DiscourseIpInfo.stubs(:get).with(gb_ip).returns(info)
+
+      SiteSetting.geoblocking_blocked_countries = "GB"
+      env = make_env("REMOTE_ADDR" => gb_ip)
+
+      status, _ = subject.call(env)
+      expect(status).to eq(403)
+    end
+
     it 'does not block static resources' do
       env = make_env(
         "REQUEST_PATH" => "/stylesheets/hello.css",


### PR DESCRIPTION
Geoname IDs are not present for all IPs. In this case, the system used
the default allow / block behavior.