### PR TITLE
FIX: ensure we're passing unmodified `env`

### DIFF
--- a/lib/geoblocking_middleware.rb
+++ b/lib/geoblocking_middleware.rb
@@ -6,10 +6,11 @@ class GeoblockingMiddleware
   end
 
   def call(env)
+    env_state = env.clone
     if SiteSetting.geoblocking_enabled && not_admin(env) && check_route(env) && is_blocked(env)
-      GeoblockingController.action('blocked').call(env)
+      GeoblockingController.action('blocked').call(env_state)
     else
-      @app.call(env)
+      @app.call(env_state)
     end
   end
 


### PR DESCRIPTION
The RSS feeds for login only forums were broken because somehow, the url
params get dropped in the process.

I've simply ensured we make a clone of the env and pass it ahead so its
resilient to modifications by methods it gets passed to