### PR TITLE
DEV: Remove `env.clone` workaround

### DIFF
--- a/lib/geoblocking_middleware.rb
+++ b/lib/geoblocking_middleware.rb
@@ -16,7 +16,7 @@ class GeoblockingMiddleware
   private
 
   def not_admin(env)
-    user = CurrentUser.lookup_from_env(env.clone)
+    user = CurrentUser.lookup_from_env(env)
     user.nil? || !user.admin?
   rescue Discourse::InvalidAccess, Discourse::ReadOnly
     true


### PR DESCRIPTION
The issues were fixed in core.

Depends on https://github.com/discourse/discourse/pull/17325 and https://github.com/discourse/discourse/pull/17326.