### PR TITLE
FEATURE: add allowed routes site setting

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -6,5 +6,6 @@ en:
     geoblocking_allowed_countries: "List of country codes (ISO 3166) that are allowed. geoblocking_blocked_countries and geoblocking_blocked_geoname_ids are ignored if this site setting is present"
     geoblocking_blocked_geoname_ids: "List of Geoname IDs that are blocked"
     geoblocking_allowed_geoname_ids: "List of Geoname IDs that are allowed. geoblocking_blocked_countries and geoblocking_blocked_geoname_ids are ignored if this site setting is present"
+    geoblocking_allowed_paths: "List of URLs that are allowed no matter the user's geographical location. Format: leading slash automatically added, exact match."
   geoblocking:
     blocked: "Access forbidden based on location."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,3 +19,7 @@ plugins:
     type: list
     default: ""
     list_type: compact
+  geoblocking_allowed_paths:
+    type: list
+    default: ""
+    list_type: compact


### PR DESCRIPTION
So that admins can configure some routes that will always be allowed even though users might be geoblocked.

FIX: the 'does not block static resources' spec wasn't testing anything

Context: https://dev.discourse.org/t/-/17503/187