### PR TITLE
FIX: allow writing an encrupted auth cookie on IP address change.

### DIFF
--- a/spec/requests/geoblocking_middleware_spec.rb
+++ b/spec/requests/geoblocking_middleware_spec.rb
@@ -185,6 +185,7 @@ describe GeoblockingMiddleware do
             "PATH_INFO" => "/",
             "HTTP_COOKIE" => "_t=#{token.unhashed_auth_token}",
           )
+        ActionDispatch::Cookies::CookieJar.any_instance.stubs(:encrypted).returns({})
         status, _ = middleware.call(env)
         expect(status).to eq(403)
       end


### PR DESCRIPTION
Follow-up to: https://github.com/discourse/discourse/pull/23395
The mentioned core PR will write a new auth cookie when user's IP address change. In RSpec, middlewares won't have encrypted object on `CookieJar` by default. So we're stubbing the empty object in this PR.